### PR TITLE
Harden security: enable Jinja2 autoescape, add SQL table whitelist, enforce HTTPS

### DIFF
--- a/core/utils_db.py
+++ b/core/utils_db.py
@@ -9,6 +9,17 @@ logger.setLevel(logging.INFO)
 # Default master database
 MASTER_DATABASE = "datasets/data.db"
 
+ALLOWED_TABLES = {
+    "resourcetype",
+    "resource_inventory",
+    "cost_inventory",
+    "risk_inventory",
+    "scoring_data",
+    "alternative",
+    "alternativetechnology",
+    "risk",
+}
+
 
 def connect(db_path=MASTER_DATABASE):
     try:
@@ -20,6 +31,8 @@ def connect(db_path=MASTER_DATABASE):
 
 
 def load_data(table_name, db_path=MASTER_DATABASE):
+    if table_name not in ALLOWED_TABLES:
+        raise ValueError(f"Disallowed table name: {table_name}")
     try:
         conn = connect(db_path)
         cursor = conn.cursor()

--- a/core/utils_report.py
+++ b/core/utils_report.py
@@ -3,7 +3,7 @@ import os
 import json
 import logging
 from typing import Any
-from jinja2 import Template
+from jinja2 import Environment
 
 # ReportLab
 from reportlab.lib.pagesizes import A4
@@ -134,7 +134,8 @@ def generate_html_report(
     with open(template_path, "r") as file:
         template_content = file.read()
 
-    template = Template(template_content)
+    env = Environment(autoescape=True)
+    template = env.from_string(template_content)
     html_content = template.render(
         **metadata,
         **scoring_context,

--- a/core/utils_sync.py
+++ b/core/utils_sync.py
@@ -20,7 +20,9 @@ _ASSESS_PATH = "/api/v1/assessments/"
 
 def _assess_url(host: str) -> str:
     host = host.strip().rstrip("/")
-    if not host.startswith("http"):
+    if host.startswith("http://"):
+        host = "https://" + host[len("http://") :]
+    elif not host.startswith("https://"):
         host = f"https://{host}"
     return f"{host}{_ASSESS_PATH}"
 

--- a/utils/connection.py
+++ b/utils/connection.py
@@ -16,7 +16,9 @@ _AUTH_PATH = "/api/v1/auth/token/"
 
 def _build_url(host: str) -> str:
     host = host.strip().rstrip("/")
-    if not host.startswith("http"):
+    if host.startswith("http://"):
+        host = "https://" + host[len("http://") :]
+    elif not host.startswith("https://"):
         host = f"https://{host}"
     return f"{host}{_AUTH_PATH}"
 

--- a/utils/sync.py
+++ b/utils/sync.py
@@ -14,7 +14,9 @@ _ASSESS_PATH = "/api/v1/assessments/"
 
 def _build_url(host: str) -> str:
     host = host.strip().rstrip("/")
-    if not host.startswith("http"):
+    if host.startswith("http://"):
+        host = "https://" + host[len("http://") :]
+    elif not host.startswith("https://"):
         host = f"https://{host}"
     return f"{host}{_ASSESS_PATH}"
 


### PR DESCRIPTION
Hardens security across the codebase by closing three vectors identified during the codebase audit.

This PR enables Jinja2 autoescape on the HTML report template to prevent XSS from user-provided or dataset-sourced fields, adds a table name whitelist in load_data() to prevent SQL injection via interpolated table names, and enforces HTTPS in all API URL builders so that http:// hosts are upgraded rather than passed through with bearer tokens in cleartext.