### PR TITLE
Fix incorrect condition for JSON report path, default currency for empty cost data, and remove dead except block

### DIFF
--- a/core/utils_aws.py
+++ b/core/utils_aws.py
@@ -254,6 +254,7 @@ def build_aws_cost_inventory(
             json.dump(cost_and_usage, raw_file, indent=4)
 
         # Insert structured data into SQLite
+        currency = "USD"
         with connect(db_path=db_path) as conn:
             cursor = conn.cursor()
 
@@ -311,10 +312,6 @@ def build_aws_cost_inventory(
 
     except sqlite3.Error as e:
         logger.error(f"SQLite error: {str(e)}", exc_info=True)
-    except Exception as e:
-        logger.error(f"Error creating AWS cost inventory: {str(e)}", exc_info=True)
-        raise
-
     except Exception as e:
         logger.error(f"Error creating AWS cost inventory: {str(e)}", exc_info=True)
         raise

--- a/core/utils_azure.py
+++ b/core/utils_azure.py
@@ -204,6 +204,7 @@ def build_azure_cost_inventory(
             json.dump(cost_data.as_dict(), raw_file, indent=4)
 
         # Insert structured cost data into SQLite
+        currency = "USD"
         with connect(db_path=db_path) as conn:
             cursor = conn.cursor()
 

--- a/main.py
+++ b/main.py
@@ -562,7 +562,7 @@ def run_assessment(config, provider_name):
         if pdf_report_path:
             console.print(f"PDF Report: {pdf_report_path}", style="cyan")
         json_report_path = report_status.get("reports", {}).get("JSON")
-        if html_report_path:
+        if json_report_path:
             console.print(f"JSON Report: {json_report_path}", style="cyan")
         console.print("-------------------------------------------")
 


### PR DESCRIPTION
Fixes three small correctness bugs found during the codebase audit.

This PR fixes a copy-paste error in main.py where the JSON report path output checked the wrong variable (html_report_path instead of json_report_path), adds a currency = "USD" default before the cost data loop in both AWS and Azure cost builders to prevent an UnboundLocalError when the cloud API returns zero rows, and removes an unreachable duplicate except Exception block at the end of build_aws_cost_inventory.