### PR TITLE
Re-raise exceptions in Azure inventory builders to propagate failures

### DIFF
--- a/core/utils_azure.py
+++ b/core/utils_azure.py
@@ -127,10 +127,13 @@ def build_azure_resource_inventory(
 
     except ClientAuthenticationError as e:
         logger.error(f"Azure authentication error: {str(e)}", exc_info=True)
+        raise
     except sqlite3.Error as e:
         logger.error(f"SQLite error: {str(e)}", exc_info=True)
+        raise
     except Exception as e:
         logger.error(f"Error fetching Azure resources: {str(e)}", exc_info=True)
+        raise
 
 
 def get_missing_months_azure(processed_costs: set[str], months_back: int) -> set[date]:
@@ -254,6 +257,7 @@ def build_azure_cost_inventory(
 
     except sqlite3.Error as e:
         logger.error(f"SQLite error: {str(e)}", exc_info=True)
+        raise
     except Exception as e:
         logger.error(f"Error creating Azure cost inventory: {str(e)}", exc_info=True)
         raise


### PR DESCRIPTION
Fixes silent error swallowing in build_azure_resource_inventory and build_azure_cost_inventory in core/utils_azure.py.

This PR adds raise after each logger.error() call in the exception handlers so that failures (authentication errors, SQLite errors, unexpected exceptions) propagate to create_resource_inventory and create_cost_inventory in core/engine.py, which already handle them and report failure to the user. Previously, these errors were logged but silently discarded, causing the assessment to continue as if the inventory step succeeded.