### PR TITLE
add Organizations with Regions and update Alt Tech Filtering

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -804,11 +804,11 @@ main {
   width: 20px;
   left: 2px;
   bottom: 2px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Ccircle cx='10' cy='10' r='10' fill='%23E5EBEB'/%3E%3Cpath d='M6.5 6.5L13.5 13.5M13.5 6.5L6.5 13.5' stroke='%234B6361' stroke-width='1.6' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Ccircle cx='10' cy='10' r='9.25' fill='white' stroke='%23D1DBDB' stroke-width='1.5'/%3E%3Cpath d='M6.5 6.5L13.5 13.5M13.5 6.5L6.5 13.5' stroke='%234B6361' stroke-width='1.6' stroke-linecap='round'/%3E%3C/svg%3E");
 }
 
 .toggle-slider:before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Ccircle cx='10' cy='10' r='10' fill='%23E5EBEB'/%3E%3Cpath d='M6.5 6.5L13.5 13.5M13.5 6.5L6.5 13.5' stroke='%234B6361' stroke-width='1.6' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Ccircle cx='10' cy='10' r='9.25' fill='white' stroke='%23D1DBDB' stroke-width='1.5'/%3E%3Cpath d='M6.5 6.5L13.5 13.5M13.5 6.5L6.5 13.5' stroke='%234B6361' stroke-width='1.6' stroke-linecap='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: center;
   background-size: 20px 20px;
@@ -822,7 +822,7 @@ input:checked + .toggle-slider:before {
   -webkit-transform: translateX(20px);
   -ms-transform: translateX(20px);
   transform: translateX(20px);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Ccircle cx='10' cy='10' r='10' fill='%230D948B'/%3E%3Cpath d='M5.5 10.5L8.5 13.5L14.5 7.5' stroke='white' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Ccircle cx='10' cy='10' r='9.25' fill='white' stroke='%230D948B' stroke-width='1.5'/%3E%3Cpath d='M5.5 10.5L8.5 13.5L14.5 7.5' stroke='%230D948B' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: center;
   background-size: 20px 20px;
@@ -910,7 +910,7 @@ td button {
   font-size: var(--text-body);
   font-style: normal;
   font-weight: 400;
-  border-radius: 16px;
+  border-radius: 8px;
   border: 1px solid var(--neutral-300);
   background: var(--white);
   -webkit-transition: border-color 0.3s ease, box-shadow 0.3s ease;
@@ -918,6 +918,16 @@ td button {
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   -webkit-box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+}
+
+.form-select {
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%23115E59' stroke-width='1.75' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 16px 16px;
+  padding-right: 40px;
 }
 
 .form-control:focus,

--- a/assets/template/index.html
+++ b/assets/template/index.html
@@ -553,6 +553,7 @@
                       </div>
                       <div class="drop-body">
                         <div class="form-group mb-3">
+                          <label for="resourceTypeSelect" class="form-label mb-2">Resource</label>
                           <select class="form-select" id="resourceTypeSelect">
                             <option value="all" selected>Select Resource Type</option>
                             {% for resource in resource_inventory %}
@@ -560,6 +561,17 @@
                               {{ resource.name | trim }}
                             </option>
                             {% endfor %}
+                          </select>
+                        </div>
+                        <div class="form-group mb-3">
+                          <label for="regionSelect" class="form-label mb-2">Region</label>
+                          <select class="form-select" id="regionSelect">
+                            <option value="all" selected>All Regions</option>
+                            <option value="european-union">European Union</option>
+                            <option value="united-kingdom">United Kingdom</option>
+                            <option value="switzerland">Switzerland</option>
+                            <option value="united-states">United States</option>
+                            <option value="other">Other</option>
                           </select>
                         </div>
                         <div class="form-toggle-switch mb-3 d-flex justify-content-between align-items-center">
@@ -596,24 +608,37 @@
                 <div class="p-3 p-lg-4">
                   <div class="row gapy-3" id="alt-tech-grid">
                     {% if alternative_technologies %} {% for alt_tech in
-                    alternative_technologies %} {% set alt_resource = namespace(name="Resource Type " ~ alt_tech.resource_type_id) %}
-                    {% for resource in resource_inventory %}
-                      {% if resource.resource_type|string == alt_tech.resource_type_id|string %}
-                        {% set alt_resource.name = resource.name %}
-                      {% endif %}
-                    {% endfor %}
+                    alternative_technologies %}
                     <div
                       class="col-lg-6 alt-tech-item alt-tech-card-item"
                       data-resource-type="{{ alt_tech.resource_type_id }}"
                       data-open-source="{{ 'true' if alt_tech.open_source else 'false' }}"
                       data-enterprise-support="{{ 'true' if alt_tech.support_plan else 'false' }}"
+                      data-org-region="{{ alt_tech.organization_region }}"
+                      data-org-country="{{ alt_tech.organization_country_code }}"
                     >
                       <div class="p-3 p-lg-4 rounded-4 alttech-card">
                         <div
                           class="d-flex align-items-center justify-content-between alttech-title"
                         >
                           <div>
-                            <h6 class="mb-1">Category: {{ alt_resource.name }}</h6>
+                            <h6 class="mb-1 d-flex align-items-center gap-2 flex-wrap">
+                              <i class="bi bi-building"></i>
+                              <span>{{ alt_tech.organization_name }}</span>
+                              {% if alt_tech.organization_url %}
+                              <a
+                                href="{{ alt_tech.organization_url }}{% if '?' in alt_tech.organization_url %}&{% else %}?{% endif %}utm_source=escapecloud&utm_medium=referral"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                aria-label="Visit {{ alt_tech.organization_name }}"
+                                class="d-inline-flex align-items-center text-decoration-none"
+                              >
+                                <i class="bi bi-box-arrow-up-right"></i>
+                              </a>
+                              {% endif %}
+                              <span class="text-muted">|</span>
+                              <span>{% if alt_tech.organization_flag %}{{ alt_tech.organization_flag }} {% endif %}{{ alt_tech.organization_country_code }} • {{ alt_tech.organization_region_label }}</span>
+                            </h6>
                             <h3 class="mb-0">{{ alt_tech.product_name }}</h3>
                           </div>
                         </div>
@@ -816,6 +841,7 @@
           const applyFiltersBtn = document.getElementById("applyFilters");
           const clearFiltersBtn = document.getElementById("clearFilters");
           const resourceTypeSelect = document.getElementById("resourceTypeSelect");
+          const regionSelect = document.getElementById("regionSelect");
           const openSourceSwitch = document.getElementById("openSourceSwitch");
           const enterpriseSupportSwitch = document.getElementById(
             "enterpriseSupportSwitch"
@@ -828,6 +854,7 @@
             applyFiltersBtn &&
             clearFiltersBtn &&
             resourceTypeSelect &&
+            regionSelect &&
             openSourceSwitch &&
             enterpriseSupportSwitch &&
             searchInput &&
@@ -866,6 +893,7 @@
 
             function applyAlternativeFilters() {
               const selectedResourceType = resourceTypeSelect.value;
+              const selectedRegion = regionSelect.value;
               const isOpenSource = openSourceSwitch.checked;
               const hasEnterpriseSupport = enterpriseSupportSwitch.checked;
               const searchQuery = searchInput.value.trim().toLowerCase();
@@ -874,6 +902,9 @@
                 const matchesResourceType =
                   selectedResourceType === "all" ||
                   box.dataset.resourceType === selectedResourceType;
+                const matchesRegion =
+                  selectedRegion === "all" ||
+                  box.dataset.orgRegion === selectedRegion;
                 const matchesOpenSource =
                   !isOpenSource || box.dataset.openSource === "true";
                 const matchesEnterpriseSupport =
@@ -883,6 +914,7 @@
 
                 box.dataset.filtered =
                   matchesResourceType &&
+                  matchesRegion &&
                   matchesOpenSource &&
                   matchesEnterpriseSupport &&
                   matchesSearch
@@ -899,6 +931,7 @@
 
             clearFiltersBtn.addEventListener("click", function () {
               resourceTypeSelect.value = "all";
+              regionSelect.value = "all";
               openSourceSwitch.checked = false;
               enterpriseSupportSwitch.checked = false;
               searchInput.value = "";

--- a/core/engine.py
+++ b/core/engine.py
@@ -437,6 +437,9 @@ def generate_report(
         risk_definitions = load_data("risk", db_path=db_path)
         alternatives = load_data("alternative", db_path=db_path)
         alternative_technologies = load_data("alternativetechnology", db_path=db_path)
+        alternative_technology_organizations = load_data(
+            "alternativetechnologyorganization", db_path=db_path
+        )
         resource_inventory = load_data("resource_inventory", db_path=db_path)
         cost_data = load_data("cost_inventory", db_path=db_path)
         risk_data = load_data("risk_inventory", db_path=db_path)
@@ -481,6 +484,7 @@ def generate_report(
             alternatives,
             alternative_technologies,
             exit_strategy,
+            alternative_technology_organizations,
         )
 
         # Generate PDF report

--- a/core/utils_db.py
+++ b/core/utils_db.py
@@ -17,6 +17,7 @@ ALLOWED_TABLES = {
     "scoring_data",
     "alternative",
     "alternativetechnology",
+    "alternativetechnologyorganization",
     "risk",
 }
 

--- a/core/utils_report.py
+++ b/core/utils_report.py
@@ -73,6 +73,7 @@ def generate_html_report(
     alternatives: list[dict[str, Any]],
     alternative_technologies: list[dict[str, Any]],
     exit_strategy: int,
+    alternative_technology_organizations: list[dict[str, Any]] | None = None,
 ) -> str:
 
     # Transform resource inventory
@@ -117,7 +118,11 @@ def generate_html_report(
 
     # Transform alternative technologies
     alternative_technologies_data = transform_alt_tech_for_html(
-        resource_inventory, alternatives, alternative_technologies, exit_strategy
+        resource_inventory,
+        alternatives,
+        alternative_technologies,
+        exit_strategy,
+        alternative_technology_organizations=alternative_technology_organizations,
     )
 
     # Scoring Data

--- a/core/utils_report_common.py
+++ b/core/utils_report_common.py
@@ -8,6 +8,73 @@ CURRENCY_SYMBOLS = {
     "EUR": "€",
 }
 
+EU_COUNTRY_CODES = {
+    "AT",
+    "BE",
+    "BG",
+    "HR",
+    "CY",
+    "CZ",
+    "DK",
+    "EE",
+    "FI",
+    "FR",
+    "DE",
+    "GR",
+    "HU",
+    "IE",
+    "IT",
+    "LV",
+    "LT",
+    "LU",
+    "MT",
+    "NL",
+    "PL",
+    "PT",
+    "RO",
+    "SK",
+    "SI",
+    "ES",
+    "SE",
+}
+
+REGION_LABELS = {
+    "european-union": "European Union",
+    "united-kingdom": "United Kingdom",
+    "switzerland": "Switzerland",
+    "united-states": "United States",
+    "other": "Other",
+}
+
+
+def normalize_country_code(country_code: Any) -> str | None:
+    if not isinstance(country_code, str):
+        return None
+    normalized = country_code.strip().upper()
+    return normalized if len(normalized) == 2 and normalized.isalpha() else None
+
+
+def country_code_to_region(country_code: Any) -> str:
+    normalized = normalize_country_code(country_code)
+    if not normalized:
+        return "other"
+    if normalized in EU_COUNTRY_CODES:
+        return "european-union"
+    if normalized == "GB":
+        return "united-kingdom"
+    if normalized == "CH":
+        return "switzerland"
+    if normalized == "US":
+        return "united-states"
+    return "other"
+
+
+def country_code_to_flag(country_code: Any) -> str:
+    normalized = normalize_country_code(country_code)
+    if not normalized:
+        return ""
+    return chr(127397 + ord(normalized[0])) + chr(127397 + ord(normalized[1]))
+
 
 def sort_cost_data(cost_data: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return sorted(cost_data, key=lambda x: datetime.strptime(x["month"], "%Y-%m-%d"))
@@ -119,6 +186,7 @@ def summarize_alternative_technologies(
     alternatives: list[dict[str, Any]],
     alternative_technologies: list[dict[str, Any]],
     exit_strategy: int,
+    alternative_technology_organizations: list[dict[str, Any]] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     active_technologies = {
         tech["id"]: tech
@@ -129,6 +197,9 @@ def summarize_alternative_technologies(
     grouped_alt_tech: dict[str, list[dict[str, Any]]] = {
         str(resource["resource_type"]): [] for resource in resource_inventory
     }
+    organization_by_id = {
+        org["id"]: org for org in (alternative_technology_organizations or [])
+    }
 
     for alt in alternatives:
         if str(alt["strategy_type"]) != str(exit_strategy):
@@ -138,6 +209,11 @@ def summarize_alternative_technologies(
         tech = active_technologies.get(alt["alternative_technology"])
         if not tech or resource_type not in grouped_alt_tech:
             continue
+        organization = organization_by_id.get(tech.get("organization_id"))
+        organization_country_code = normalize_country_code(
+            organization.get("country_code") if organization else None
+        )
+        organization_region = country_code_to_region(organization_country_code)
 
         grouped_alt_tech[resource_type].append(
             {
@@ -147,6 +223,16 @@ def summarize_alternative_technologies(
                 "open_source": tech["open_source"] == "t",
                 "support_plan": tech["support_plan"] == "t",
                 "status": tech["status"] == "t",
+                "organization_name": (
+                    organization.get("name") if organization else "Unknown Organization"
+                ),
+                "organization_url": organization.get("url") if organization else None,
+                "organization_country_code": organization_country_code or "N/A",
+                "organization_region": organization_region,
+                "organization_region_label": REGION_LABELS.get(
+                    organization_region, "Other"
+                ),
+                "organization_flag": country_code_to_flag(organization_country_code),
             }
         )
 

--- a/core/utils_report_html.py
+++ b/core/utils_report_html.py
@@ -42,6 +42,7 @@ def transform_alt_tech_for_html(
     alternatives: list[dict[str, Any]],
     alternative_technologies: list[dict[str, Any]],
     exit_strategy: int,
+    alternative_technology_organizations: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     alt_tech_data = []
     grouped_alt_tech = summarize_alternative_technologies(
@@ -49,6 +50,7 @@ def transform_alt_tech_for_html(
         alternatives,
         alternative_technologies,
         exit_strategy,
+        alternative_technology_organizations=alternative_technology_organizations,
     )
     for resource in resource_inventory:
         resource_type = str(resource.get("resource_type"))

--- a/tests/report_fixtures.py
+++ b/tests/report_fixtures.py
@@ -57,6 +57,17 @@ def build_report_fixture():
             "open_source": "t",
             "support_plan": "t",
             "status": "t",
+            "organization_id": 10,
+        }
+    ]
+    alternative_technology_organizations = [
+        {
+            "id": 10,
+            "name": "OpenInfra Foundation",
+            "url": "https://openinfra.org/",
+            "country_code": "US",
+            "stability_tier": 5,
+            "years_in_business": 14,
         }
     ]
     return {
@@ -69,6 +80,7 @@ def build_report_fixture():
         "risk_data": risk_data,
         "alternatives": alternatives,
         "alternative_technologies": alternative_technologies,
+        "alternative_technology_organizations": alternative_technology_organizations,
         "exit_strategy": 1,
     }
 
@@ -96,6 +108,7 @@ def build_empty_report_fixture():
         "risk_data": [],
         "alternatives": [],
         "alternative_technologies": [],
+        "alternative_technology_organizations": [],
         "exit_strategy": 1,
     }
 

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -33,6 +33,7 @@ class ReportPipelineSmokeTests(unittest.TestCase):
                 fixture["alternatives"],
                 fixture["alternative_technologies"],
                 fixture["exit_strategy"],
+                fixture["alternative_technology_organizations"],
             )
 
             self.assertTrue(Path(html_path).exists())
@@ -41,6 +42,9 @@ class ReportPipelineSmokeTests(unittest.TestCase):
         self.assertIn("Smoke Test Assessment", html)
         self.assertIn("Amazon Web Services", html)
         self.assertIn("OpenStack", html)
+        self.assertIn("OpenInfra Foundation", html)
+        self.assertIn("All Regions", html)
+        self.assertIn("data-org-region", html)
         self.assertIn("EC2 Instance", html)
 
     def test_generate_html_report_renders_empty_state_output(self):
@@ -59,6 +63,7 @@ class ReportPipelineSmokeTests(unittest.TestCase):
                 fixture["alternatives"],
                 fixture["alternative_technologies"],
                 fixture["exit_strategy"],
+                fixture["alternative_technology_organizations"],
             )
 
             self.assertTrue(Path(html_path).exists())

--- a/tests/test_report_transforms.py
+++ b/tests/test_report_transforms.py
@@ -86,6 +86,7 @@ def build_alternative_technologies():
             "open_source": "t",
             "support_plan": "t",
             "status": "t",
+            "organization_id": 10,
         },
         {
             "id": 2,
@@ -95,6 +96,7 @@ def build_alternative_technologies():
             "open_source": "t",
             "support_plan": "f",
             "status": "t",
+            "organization_id": 20,
         },
         {
             "id": 3,
@@ -104,6 +106,23 @@ def build_alternative_technologies():
             "open_source": "t",
             "support_plan": "t",
             "status": "f",
+        },
+    ]
+
+
+def build_alternative_technology_organizations():
+    return [
+        {
+            "id": 10,
+            "name": "OpenInfra Foundation",
+            "url": "https://openinfra.org/",
+            "country_code": "US",
+        },
+        {
+            "id": 20,
+            "name": "European Storage Collective",
+            "url": "https://example.eu/",
+            "country_code": "DE",
         },
     ]
 
@@ -151,6 +170,7 @@ class HtmlTransformTests(unittest.TestCase):
             build_alternatives(),
             build_alternative_technologies(),
             exit_strategy=1,
+            alternative_technology_organizations=build_alternative_technology_organizations(),
         )
 
         self.assertEqual(len(transformed), 2)
@@ -158,6 +178,9 @@ class HtmlTransformTests(unittest.TestCase):
         self.assertEqual(transformed[1]["product_name"], "MinIO")
         self.assertTrue(transformed[0]["open_source"])
         self.assertFalse(transformed[1]["support_plan"])
+        self.assertEqual(transformed[0]["organization_name"], "OpenInfra Foundation")
+        self.assertEqual(transformed[0]["organization_region"], "united-states")
+        self.assertEqual(transformed[1]["organization_region"], "european-union")
 
 
 class JsonTransformTests(unittest.TestCase):


### PR DESCRIPTION
Adds organization metadata support to alternative technology rendering and introduces region-based filtering in the HTML report UI.

This PR loads alternativetechnologyorganization data from the assessment database and enriches alt-tech entries with organization name, URL, country code, country flag, and derived region bucket. It updates the filter panel by adding a Region dropdown under Resource and applies region filtering with the agreed buckets (European Union, United Kingdom, Switzerland, United States, Other) while preserving existing search/open-source/support filters.