### PR TITLE
fix host key env sync

### DIFF
--- a/core/utils_sync.py
+++ b/core/utils_sync.py
@@ -95,9 +95,13 @@ def post_assessment(
     token: str,
     timeout: int = 10,
 ) -> dict[str, Any]:
-    host = getattr(config, "HOST", "").strip()
+    host = os.environ.get("HOST", "").strip() or getattr(config, "HOST", "").strip()
     if not host:
-        return {"success": False, "payload": None, "logs": "HOST missing in config.py"}
+        return {
+            "success": False,
+            "payload": None,
+            "logs": "HOST missing in environment and config.py",
+        }
 
     url = _assess_url(host)
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}

--- a/tests/test_utils_and_main.py
+++ b/tests/test_utils_and_main.py
@@ -443,7 +443,7 @@ class ResolveModeEnvVarTests(unittest.TestCase):
 
     def test_falls_back_to_config_when_env_not_set(self):
         fake_config = types.SimpleNamespace(HOST="", KEY="")
-        env = {k: v for k, v in os.environ.items() if k not in ("ESC_HOST", "ESC_KEY")}
+        env = {k: v for k, v in os.environ.items() if k not in ("HOST", "KEY")}
         with (
             patch("utils.connection.config", fake_config),
             patch.dict(os.environ, env, clear=True),

--- a/tests/test_utils_sync.py
+++ b/tests/test_utils_sync.py
@@ -15,9 +15,14 @@ class PostAssessmentHostResolutionTests(unittest.TestCase):
 
         with (
             patch.dict(os.environ, {"HOST": "env.exitcloud.io"}, clear=False),
-            patch("core.utils_sync.config", types.SimpleNamespace(HOST="", CLI_VERSION="v1")),
+            patch(
+                "core.utils_sync.config",
+                types.SimpleNamespace(HOST="", CLI_VERSION="v1"),
+            ),
             patch("core.utils_sync._build_payload", return_value={"sample": "payload"}),
-            patch("core.utils_sync.requests.post", return_value=fake_response) as mock_post,
+            patch(
+                "core.utils_sync.requests.post", return_value=fake_response
+            ) as mock_post,
         ):
             result = post_assessment(
                 name="Demo",
@@ -33,14 +38,15 @@ class PostAssessmentHostResolutionTests(unittest.TestCase):
 
         self.assertTrue(result["success"])
         called_url = mock_post.call_args.args[0]
-        self.assertEqual(
-            called_url, "https://env.exitcloud.io/api/v1/assessments/"
-        )
+        self.assertEqual(called_url, "https://env.exitcloud.io/api/v1/assessments/")
 
     def test_returns_clear_error_when_host_missing_everywhere(self):
         with (
             patch.dict(os.environ, {}, clear=True),
-            patch("core.utils_sync.config", types.SimpleNamespace(HOST="", CLI_VERSION="v1")),
+            patch(
+                "core.utils_sync.config",
+                types.SimpleNamespace(HOST="", CLI_VERSION="v1"),
+            ),
         ):
             result = post_assessment(
                 name="Demo",

--- a/tests/test_utils_sync.py
+++ b/tests/test_utils_sync.py
@@ -1,0 +1,63 @@
+import os
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+from core.utils_sync import post_assessment
+
+
+class PostAssessmentHostResolutionTests(unittest.TestCase):
+    def test_uses_host_from_environment_when_config_host_empty(self):
+        fake_response = MagicMock()
+        fake_response.ok = True
+        fake_response.status_code = 200
+        fake_response.json.return_value = {"data": {"ok": True}}
+
+        with (
+            patch.dict(os.environ, {"HOST": "env.exitcloud.io"}, clear=False),
+            patch("core.utils_sync.config", types.SimpleNamespace(HOST="", CLI_VERSION="v1")),
+            patch("core.utils_sync._build_payload", return_value={"sample": "payload"}),
+            patch("core.utils_sync.requests.post", return_value=fake_response) as mock_post,
+        ):
+            result = post_assessment(
+                name="Demo",
+                started_at=123,
+                report_path="/tmp/report",
+                meta={
+                    "exit_strategy": 1,
+                    "cloud_service_provider": 2,
+                    "assessment_type": 1,
+                },
+                token="jwt-token",
+            )
+
+        self.assertTrue(result["success"])
+        called_url = mock_post.call_args.args[0]
+        self.assertEqual(
+            called_url, "https://env.exitcloud.io/api/v1/assessments/"
+        )
+
+    def test_returns_clear_error_when_host_missing_everywhere(self):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("core.utils_sync.config", types.SimpleNamespace(HOST="", CLI_VERSION="v1")),
+        ):
+            result = post_assessment(
+                name="Demo",
+                started_at=123,
+                report_path="/tmp/report",
+                meta={
+                    "exit_strategy": 1,
+                    "cloud_service_provider": 2,
+                    "assessment_type": 1,
+                },
+                token="jwt-token",
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["payload"], None)
+        self.assertEqual(result["logs"], "HOST missing in environment and config.py")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix online sync host resolution by making `post_assessment` use env-first lookup (`HOST`, then `config.py`) consistently with connection mode resolution.  

Also adds focused tests to cover env override and missing-host error behavior.