### PR TITLE
Add OIDC support for non-interactive AWS and Azure assessments

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import boto3
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Any
 from azure.identity import ClientSecretCredential
 from azure.mgmt.resource import ResourceManagementClient
@@ -142,33 +142,93 @@ def test_permissions(
                 region_name=provider_details["region"],
             )
             identity = sts_client.get_caller_identity()
-            user_arn = identity["Arn"]
-            user_name = user_arn.split("/")[-1]
+            caller_arn = identity.get("Arn", "")
 
-            iam_client = boto3.client(
-                "iam",
-                aws_access_key_id=provider_details["accessKey"],
-                aws_secret_access_key=provider_details["secretKey"],
-                aws_session_token=provider_details.get("sessionToken"),
-                region_name=provider_details["region"],
-            )
-            policies = iam_client.list_attached_user_policies(UserName=user_name)
-            policy_names = [
-                policy["PolicyName"] for policy in policies["AttachedPolicies"]
-            ]
+            # IAM users keep existing policy-name validation for backwards compatibility.
+            if ":user/" in caller_arn:
+                user_name = caller_arn.split("/")[-1]
+                iam_client = boto3.client(
+                    "iam",
+                    aws_access_key_id=provider_details["accessKey"],
+                    aws_secret_access_key=provider_details["secretKey"],
+                    aws_session_token=provider_details.get("sessionToken"),
+                    region_name=provider_details["region"],
+                )
+                policies = iam_client.list_attached_user_policies(UserName=user_name)
+                policy_names = [
+                    policy["PolicyName"] for policy in policies["AttachedPolicies"]
+                ]
 
-            permission_reader = "ViewOnlyAccess" in policy_names
-            permission_cost = "AWSBillingReadOnlyAccess" in policy_names
+                permission_reader = "ViewOnlyAccess" in policy_names
+                permission_cost = "AWSBillingReadOnlyAccess" in policy_names
 
-            if permission_reader and permission_cost:
-                permission_valid = True
-                logs = "ViewOnlyAccess and AWSBillingReadOnlyAccess policies validated."
-            elif permission_reader:
-                logs = "ViewOnlyAccess policy validated, but AWSBillingReadOnlyAccess policy validation failed."
-            elif permission_cost:
-                logs = "AWSBillingReadOnlyAccess policy validated, but ViewOnlyAccess policy validation failed."
+                if permission_reader and permission_cost:
+                    permission_valid = True
+                    logs = "ViewOnlyAccess and AWSBillingReadOnlyAccess policies validated."
+                elif permission_reader:
+                    logs = "ViewOnlyAccess policy validated, but AWSBillingReadOnlyAccess policy validation failed."
+                elif permission_cost:
+                    logs = "AWSBillingReadOnlyAccess policy validated, but ViewOnlyAccess policy validation failed."
+                else:
+                    logs = "Both ViewOnlyAccess and AWSBillingReadOnlyAccess policy validations failed."
             else:
-                logs = "Both ViewOnlyAccess and AWSBillingReadOnlyAccess policy validations failed."
+                # Assumed roles/federated identities (e.g. GitHub OIDC) are validated by capabilities.
+                reader_error = ""
+                cost_error = ""
+
+                try:
+                    ec2_client = boto3.client(
+                        "ec2",
+                        aws_access_key_id=provider_details["accessKey"],
+                        aws_secret_access_key=provider_details["secretKey"],
+                        aws_session_token=provider_details.get("sessionToken"),
+                        region_name=provider_details["region"],
+                    )
+                    ec2_client.describe_regions()
+                    permission_reader = True
+                except Exception as e:
+                    reader_error = str(e)
+
+                try:
+                    ce_client = boto3.client(
+                        "ce",
+                        aws_access_key_id=provider_details["accessKey"],
+                        aws_secret_access_key=provider_details["secretKey"],
+                        aws_session_token=provider_details.get("sessionToken"),
+                        region_name="us-east-1",
+                    )
+                    today = datetime.now(timezone.utc).date()
+                    ce_client.get_cost_and_usage(
+                        TimePeriod={
+                            "Start": today.replace(day=1).isoformat(),
+                            "End": (today + timedelta(days=1)).isoformat(),
+                        },
+                        Granularity="MONTHLY",
+                        Metrics=["UnblendedCost"],
+                    )
+                    permission_cost = True
+                except Exception as e:
+                    cost_error = str(e)
+
+                if permission_reader and permission_cost:
+                    permission_valid = True
+                    logs = (
+                        "AWS role/federated capability checks validated "
+                        "(ec2:DescribeRegions and ce:GetCostAndUsage)."
+                    )
+                elif permission_reader:
+                    logs = "AWS capability checks: ec2:DescribeRegions validated, but ce:GetCostAndUsage failed."
+                    if cost_error:
+                        logs += f" Details: {cost_error}"
+                elif permission_cost:
+                    logs = "AWS capability checks: ce:GetCostAndUsage validated, but ec2:DescribeRegions failed."
+                    if reader_error:
+                        logs += f" Details: {reader_error}"
+                else:
+                    logs = "AWS capability checks failed for both ec2:DescribeRegions and ce:GetCostAndUsage."
+                    details = ", ".join(d for d in [reader_error, cost_error] if d)
+                    if details:
+                        logs += f" Details: {details}"
 
         except NoCredentialsError as e:
             logs = f"AWS credentials validation failed: {str(e)}"

--- a/core/engine.py
+++ b/core/engine.py
@@ -61,6 +61,7 @@ def verify_credentials(
                 "ec2",
                 aws_access_key_id=provider_details["accessKey"],
                 aws_secret_access_key=provider_details["secretKey"],
+                aws_session_token=provider_details.get("sessionToken"),
                 region_name=provider_details["region"],
             )
             client.describe_regions()  # Benign call to verify credentials
@@ -137,6 +138,7 @@ def test_permissions(
                 "sts",
                 aws_access_key_id=provider_details["accessKey"],
                 aws_secret_access_key=provider_details["secretKey"],
+                aws_session_token=provider_details.get("sessionToken"),
                 region_name=provider_details["region"],
             )
             identity = sts_client.get_caller_identity()
@@ -147,6 +149,7 @@ def test_permissions(
                 "iam",
                 aws_access_key_id=provider_details["accessKey"],
                 aws_secret_access_key=provider_details["secretKey"],
+                aws_session_token=provider_details.get("sessionToken"),
                 region_name=provider_details["region"],
             )
             policies = iam_client.list_attached_user_policies(UserName=user_name)

--- a/core/utils_aws.py
+++ b/core/utils_aws.py
@@ -76,6 +76,7 @@ def build_aws_resource_inventory(
         session = boto3.Session(
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
+            aws_session_token=provider_details.get("sessionToken"),
             region_name=region,
         )
 
@@ -225,6 +226,7 @@ def build_aws_cost_inventory(
         session = boto3.Session(
             aws_access_key_id=provider_details["accessKey"],
             aws_secret_access_key=provider_details["secretKey"],
+            aws_session_token=provider_details.get("sessionToken"),
             region_name=provider_details["region"],
         )
         cost_explorer = session.client("ce", region_name="us-east-1")

--- a/main.py
+++ b/main.py
@@ -287,6 +287,9 @@ def handle_azure(args):
         )
         subscription_id = require_env("ESC_SUBSCRIPTION_ID", "Azure subscription ID")
         resource_group = require_env("ESC_RESOURCE_GROUP", "Azure resource group")
+        tenant_id = require_env("AZURE_TENANT_ID", "Azure tenant ID")
+        client_id = os.environ.get("AZURE_CLIENT_ID", "").strip()
+        client_secret = os.environ.get("AZURE_CLIENT_SECRET", "").strip()
 
         if args.cli:
             if not is_azure_cli_installed():
@@ -307,17 +310,37 @@ def handle_azure(args):
                     "[bold cyan]az login --scope https://management.azure.com/.default[/bold cyan]"
                 )
                 sys.exit(codes.CONFIG)
-            tenant_id = require_env("AZURE_TENANT_ID", "Azure tenant ID")
             credential = DefaultAzureCredential()
         else:
-            tenant_id = require_env("AZURE_TENANT_ID", "Azure tenant ID")
-            client_id = require_env("AZURE_CLIENT_ID", "Azure client ID")
-            client_secret = require_env("AZURE_CLIENT_SECRET", "Azure client secret")
-            credential = ClientSecretCredential(
-                tenant_id=tenant_id,
-                client_id=client_id,
-                client_secret=client_secret,
-            )
+            if client_secret:
+                if not client_id:
+                    console.print(
+                        "[red]--non-interactive with AZURE_CLIENT_SECRET also requires AZURE_CLIENT_ID.[/red]"
+                    )
+                    sys.exit(codes.CONFIG)
+                credential = ClientSecretCredential(
+                    tenant_id=tenant_id,
+                    client_id=client_id,
+                    client_secret=client_secret,
+                )
+            else:
+                if not client_id:
+                    console.print(
+                        "[red]--non-interactive Azure OIDC requires AZURE_CLIENT_ID when AZURE_CLIENT_SECRET is not set.[/red]"
+                    )
+                    sys.exit(codes.CONFIG)
+                credential = DefaultAzureCredential()
+
+        provider_details = {
+            "credential": credential,
+            "tenantId": tenant_id,
+            "subscriptionId": subscription_id,
+            "resourceGroupName": resource_group,
+        }
+        if client_id:
+            provider_details["clientId"] = client_id
+        if not args.cli and client_secret:
+            provider_details["clientSecret"] = client_secret
 
         config = {
             "name": (
@@ -328,17 +351,7 @@ def handle_azure(args):
             "cloudServiceProvider": cloud_provider,
             "exitStrategy": exit_strategy,
             "assessmentType": assessment_type,
-            "providerDetails": {
-                "credential": credential,
-                "tenantId": tenant_id,
-                "subscriptionId": subscription_id,
-                "resourceGroupName": resource_group,
-                **(
-                    {}
-                    if args.cli
-                    else {"clientId": client_id, "clientSecret": client_secret}
-                ),
-            },
+            "providerDetails": provider_details,
         }
 
     elif args.cli:

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import argparse
 import boto3
 import time
 import sys
+import os
 from rich.console import Console
 from datetime import datetime
 from botocore.exceptions import NoCredentialsError, ProfileNotFound
@@ -115,6 +116,13 @@ def handle_aws(args):
             except (NoCredentialsError, ProfileNotFound) as e:
                 console.print(f"[red]AWS profile error: {str(e)}.[/red]")
                 sys.exit(codes.CONFIG)
+            provider_details = {
+                "accessKey": credentials.access_key,
+                "secretKey": credentials.secret_key,
+                "region": region,
+            }
+            if getattr(credentials, "token", None):
+                provider_details["sessionToken"] = credentials.token
             config = {
                 "name": (
                     args.name.strip()
@@ -124,21 +132,25 @@ def handle_aws(args):
                 "cloudServiceProvider": cloud_provider,
                 "exitStrategy": exit_strategy,
                 "assessmentType": assessment_type,
-                "providerDetails": {
-                    "accessKey": credentials.access_key,
-                    "secretKey": credentials.secret_key,
-                    "region": region,
-                },
+                "providerDetails": provider_details,
             }
         else:
             access_key = require_env("AWS_ACCESS_KEY_ID", "AWS access key")
             secret_key = require_env("AWS_SECRET_ACCESS_KEY", "AWS secret key")
             region = require_env("AWS_DEFAULT_REGION", "AWS region")
+            session_token = os.environ.get("AWS_SESSION_TOKEN", "").strip()
             try:
                 validate_region(region)
             except ValueError as e:
                 console.print(f"[red]AWS_DEFAULT_REGION: {e}[/red]")
                 sys.exit(codes.CONFIG)
+            provider_details = {
+                "accessKey": access_key,
+                "secretKey": secret_key,
+                "region": region,
+            }
+            if session_token:
+                provider_details["sessionToken"] = session_token
             config = {
                 "name": (
                     args.name.strip()
@@ -148,11 +160,7 @@ def handle_aws(args):
                 "cloudServiceProvider": cloud_provider,
                 "exitStrategy": exit_strategy,
                 "assessmentType": assessment_type,
-                "providerDetails": {
-                    "accessKey": access_key,
-                    "secretKey": secret_key,
-                    "region": region,
-                },
+                "providerDetails": provider_details,
             }
 
     elif args.profile:
@@ -185,6 +193,13 @@ def handle_aws(args):
             # logger.info(f"Using AWS profile '{args.profile}' with region '{region}'.")
 
             exit_strategy, assessment_type = prompt_required_inputs()
+            provider_details = {
+                "accessKey": credentials.access_key,
+                "secretKey": credentials.secret_key,
+                "region": region,
+            }
+            if getattr(credentials, "token", None):
+                provider_details["sessionToken"] = credentials.token
             config = {
                 "name": (
                     args.name.strip()
@@ -194,11 +209,7 @@ def handle_aws(args):
                 "cloudServiceProvider": cloud_provider,
                 "exitStrategy": exit_strategy,
                 "assessmentType": assessment_type,
-                "providerDetails": {
-                    "accessKey": credentials.access_key,
-                    "secretKey": credentials.secret_key,
-                    "region": region,
-                },
+                "providerDetails": provider_details,
             }
         except (NoCredentialsError, ProfileNotFound) as e:
             # logger.error(f"AWS profile error: {e}", exc_info=True)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,109 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from core.engine import test_permissions
+
+
+class TestPermissionsAwsHybridMode(unittest.TestCase):
+    def setUp(self):
+        self.provider_details = {
+            "accessKey": "AKIAEXAMPLE",
+            "secretKey": "secret-example",
+            "sessionToken": "session-token",
+            "region": "eu-central-1",
+        }
+
+    @patch("core.engine.boto3.client")
+    def test_iam_user_keeps_policy_based_validation(self, mock_boto_client):
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123456789012:user/test-user"
+        }
+        iam_client = MagicMock()
+        iam_client.list_attached_user_policies.return_value = {
+            "AttachedPolicies": [
+                {"PolicyName": "ViewOnlyAccess"},
+                {"PolicyName": "AWSBillingReadOnlyAccess"},
+            ]
+        }
+
+        def client_side_effect(service_name, **kwargs):
+            if service_name == "sts":
+                return sts_client
+            if service_name == "iam":
+                return iam_client
+            raise AssertionError(f"Unexpected service requested: {service_name}")
+
+        mock_boto_client.side_effect = client_side_effect
+
+        permission_valid, permission_reader, permission_cost, logs = test_permissions(
+            2, self.provider_details
+        )
+
+        self.assertTrue(permission_valid)
+        self.assertTrue(permission_reader)
+        self.assertTrue(permission_cost)
+        self.assertIn("policies validated", logs)
+
+    @patch("core.engine.boto3.client")
+    def test_assumed_role_uses_capability_checks(self, mock_boto_client):
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/GitHub_Actions/runner"
+        }
+        ec2_client = MagicMock()
+        ce_client = MagicMock()
+
+        def client_side_effect(service_name, **kwargs):
+            if service_name == "sts":
+                return sts_client
+            if service_name == "ec2":
+                return ec2_client
+            if service_name == "ce":
+                return ce_client
+            raise AssertionError(f"Unexpected service requested: {service_name}")
+
+        mock_boto_client.side_effect = client_side_effect
+
+        permission_valid, permission_reader, permission_cost, logs = test_permissions(
+            2, self.provider_details
+        )
+
+        self.assertTrue(permission_valid)
+        self.assertTrue(permission_reader)
+        self.assertTrue(permission_cost)
+        self.assertIn("capability checks validated", logs)
+
+    @patch("core.engine.boto3.client")
+    def test_assumed_role_cost_capability_failure(self, mock_boto_client):
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/GitHub_Actions/runner"
+        }
+        ec2_client = MagicMock()
+        ce_client = MagicMock()
+        ce_client.get_cost_and_usage.side_effect = Exception("AccessDenied")
+
+        def client_side_effect(service_name, **kwargs):
+            if service_name == "sts":
+                return sts_client
+            if service_name == "ec2":
+                return ec2_client
+            if service_name == "ce":
+                return ce_client
+            raise AssertionError(f"Unexpected service requested: {service_name}")
+
+        mock_boto_client.side_effect = client_side_effect
+
+        permission_valid, permission_reader, permission_cost, logs = test_permissions(
+            2, self.provider_details
+        )
+
+        self.assertFalse(permission_valid)
+        self.assertTrue(permission_reader)
+        self.assertFalse(permission_cost)
+        self.assertIn("ce:GetCostAndUsage failed", logs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils_and_main.py
+++ b/tests/test_utils_and_main.py
@@ -499,6 +499,42 @@ class NonInteractiveAzureTests(unittest.TestCase):
         self.assertEqual(config_arg["providerDetails"]["subscriptionId"], "sub-id-789")
         self.assertEqual(config_arg["providerDetails"]["resourceGroupName"], "my-rg")
 
+    def test_uses_default_credential_when_client_secret_missing(self):
+        env = {k: v for k, v in self._BASE_ENV.items() if k != "AZURE_CLIENT_SECRET"}
+        mock_credential = MagicMock()
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch("main.DefaultAzureCredential", return_value=mock_credential),
+            patch("main.ClientSecretCredential") as mock_client_secret_cred,
+            patch("main.run_assessment") as mock_run,
+            patch("main.console.print"),
+        ):
+            main.handle_azure(_ni_azure_args())
+
+        mock_client_secret_cred.assert_not_called()
+        mock_run.assert_called_once()
+        config_arg = mock_run.call_args[0][0]
+        self.assertEqual(config_arg["providerDetails"]["credential"], mock_credential)
+        self.assertEqual(config_arg["providerDetails"]["tenantId"], "tenant-id-123")
+        self.assertEqual(config_arg["providerDetails"]["subscriptionId"], "sub-id-789")
+        self.assertEqual(config_arg["providerDetails"]["resourceGroupName"], "my-rg")
+        self.assertEqual(config_arg["providerDetails"]["clientId"], "client-id-456")
+        self.assertNotIn("clientSecret", config_arg["providerDetails"])
+
+    def test_missing_client_id_for_oidc_exits_config(self):
+        env = {
+            k: v
+            for k, v in self._BASE_ENV.items()
+            if k not in ("AZURE_CLIENT_SECRET", "AZURE_CLIENT_ID")
+        }
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch("main.console.print"),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main.handle_azure(_ni_azure_args())
+        self.assertEqual(ctx.exception.code, codes.CONFIG)
+
     def test_missing_subscription_id_exits_config(self):
         env = {k: v for k, v in self._BASE_ENV.items() if k != "ESC_SUBSCRIPTION_ID"}
         with (

--- a/tests/test_utils_and_main.py
+++ b/tests/test_utils_and_main.py
@@ -425,6 +425,21 @@ class NonInteractiveAWSTests(unittest.TestCase):
         )
         self.assertEqual(config_arg["providerDetails"]["region"], "eu-central-1")
 
+    def test_includes_optional_session_token_from_env(self):
+        env = {**self._BASE_ENV, "AWS_SESSION_TOKEN": "sts-session-token"}
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch("main.validate_region"),
+            patch("main.run_assessment") as mock_run,
+            patch("main.console.print"),
+        ):
+            main.handle_aws(_ni_aws_args())
+
+        config_arg = mock_run.call_args[0][0]
+        self.assertEqual(
+            config_arg["providerDetails"]["sessionToken"], "sts-session-token"
+        )
+
     def test_missing_exit_strategy_exits_config(self):
         env = {k: v for k, v in self._BASE_ENV.items() if k != "ESC_EXIT_STRATEGY"}
         with (

--- a/tests/test_utils_aws.py
+++ b/tests/test_utils_aws.py
@@ -196,6 +196,48 @@ class AwsApiCallWithRetryTests(unittest.TestCase):
 class BuildAwsCostInventoryErrorTests(unittest.TestCase):
     @patch("core.utils_aws.connect")
     @patch("core.utils_aws.boto3.Session")
+    def test_passes_session_token_to_boto3_session(
+        self, mock_session_cls, mock_connect
+    ):
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_ce = MagicMock()
+        mock_session.client.return_value = mock_ce
+        mock_ce.get_cost_and_usage.return_value = {"ResultsByTime": []}
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        from core.utils_aws import build_aws_cost_inventory
+
+        with tempfile.TemporaryDirectory() as tmp:
+            report_path = os.path.join(tmp, "report")
+            raw_data_path = os.path.join(tmp, "raw")
+            os.makedirs(os.path.join(report_path, "data"), exist_ok=True)
+            os.makedirs(raw_data_path, exist_ok=True)
+
+            build_aws_cost_inventory(
+                2,
+                {
+                    "accessKey": "AK",
+                    "secretKey": "SK",
+                    "sessionToken": "TOKEN",
+                    "region": "us-east-1",
+                },
+                report_path,
+                raw_data_path,
+            )
+
+        mock_session_cls.assert_called_once_with(
+            aws_access_key_id="AK",
+            aws_secret_access_key="SK",
+            aws_session_token="TOKEN",
+            region_name="us-east-1",
+        )
+
+    @patch("core.utils_aws.connect")
+    @patch("core.utils_aws.boto3.Session")
     def test_sqlite_error_is_logged_but_not_reraised(
         self, mock_session_cls, mock_connect
     ):


### PR DESCRIPTION
This PR extends `cloudexit` non-interactive authentication to support OIDC-based credentials for both AWS and Azure, while preserving existing static credential behavior.

For AWS, it adds support for temporary session credentials (`AWS_SESSION_TOKEN`) and updates Stage 2 permission validation to work for both IAM users and assumed-role identities (including GitHub OIDC).
For Azure, it enables non-interactive OIDC execution via `DefaultAzureCredential` when `AZURE_CLIENT_SECRET` is not provided, while keeping the existing client-secret flow unchanged.

### What changed
- **AWS non-interactive auth**
  - Added optional `AWS_SESSION_TOKEN` handling across the AWS execution pipeline.
- **AWS Stage 2 permission checks**
  - Kept policy-name checks for IAM user identities.
  - Added capability-based checks for role/federated identities:
    - `ec2:DescribeRegions`
    - `ce:GetCostAndUsage`
    
- **Azure non-interactive auth**
  - Added OIDC-compatible path using `DefaultAzureCredential` (no client secret required).
  - Retained static client-secret path for backward compatibility.
  
- **Tests**
  - Added/updated unit tests covering AWS session token propagation, AWS role-based permission validation, and Azure OIDC non-interactive behavior.
  
