### PR TITLE
Add pyproject.toml packaging with cloudexit entrypoint

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core assessment and reporting modules."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cloudexit"
+version = "1.0.0"
+description = "Open-source cloud exit assessment CLI for evaluating cloud lock-in risk."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "azure-identity==1.25.3",
+    "azure-mgmt-resource==24.0.0",
+    "azure-mgmt-authorization==4.0.0",
+    "azure-mgmt-costmanagement==4.0.1",
+    "boto3==1.43.5",
+    "botocore==1.43.5",
+    "rich==15.0.0",
+    "Jinja2==3.1.6",
+    "reportlab==4.5.0",
+    "pillow==12.2.0",
+    "plotly==6.7.0",
+    "kaleido==1.3.0",
+    "requests==2.33.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black",
+    "ruff",
+]
+
+[project.scripts]
+cloudexit = "main:main"
+
+[tool.setuptools]
+py-modules = ["main", "config"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["core", "core.*", "utils", "utils.*"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utility modules used by the CLI."""

--- a/utils/data.py
+++ b/utils/data.py
@@ -140,9 +140,10 @@ def initialize_dataset() -> None:
                 f"[INFO] Download successful. Extracting dataset from {latest_file}..."
             )
 
-            with gzip.open(local_compressed_path, "rb") as f_in, open(
-                local_db_path, "wb"
-            ) as f_out:
+            with (
+                gzip.open(local_compressed_path, "rb") as f_in,
+                open(local_db_path, "wb") as f_out,
+            ):
                 shutil.copyfileobj(f_in, f_out)
 
             print("[INFO] Dataset updated successfully.")


### PR DESCRIPTION
This PR introduces pyproject.toml-based packaging and a cloudexit CLI entrypoint, adds minimal package markers.