### PR TITLE
Unify CLI config-failure exit codes via a single ConfigError catch

### DIFF
--- a/main.py
+++ b/main.py
@@ -162,7 +162,7 @@ def handle_aws(args):
         config = load_config(args.config)
         if not config:
             console.print("[red]Invalid or missing AWS configuration file.[/red]")
-            return
+            raise ConfigError
 
         # Handle name field logic (priority: --name > config name > fallback)
         if args.name:
@@ -182,25 +182,16 @@ def handle_aws(args):
         assessment_type = require_env_int(
             "ESC_ASSESSMENT_TYPE", "assessment type (1 or 2)", {1, 2}
         )
-        try:
-            if args.profile:
-                provider_details = _aws_provider_from_profile(args.profile)
-            else:
-                provider_details = _aws_provider_from_env()
-        except ConfigError:
-            sys.exit(codes.CONFIG)
-    elif args.profile:
-        try:
+        if args.profile:
             provider_details = _aws_provider_from_profile(args.profile)
-        except ConfigError:
-            return
+        else:
+            provider_details = _aws_provider_from_env()
+    elif args.profile:
+        provider_details = _aws_provider_from_profile(args.profile)
         exit_strategy, assessment_type = prompt_required_inputs()
     else:
         exit_strategy, assessment_type = prompt_required_inputs()
-        try:
-            provider_details = _aws_provider_from_prompt()
-        except ConfigError:
-            return
+        provider_details = _aws_provider_from_prompt()
 
     config = build_config(
         cloud_provider, exit_strategy, assessment_type, provider_details, args
@@ -364,7 +355,7 @@ def handle_azure(args):
         config = load_config(args.config)
         if not config:
             console.print("[red]Invalid or missing Azure configuration file.[/red]")
-            return
+            raise ConfigError
 
         # Handle name field logic (priority: --name > config name > fallback)
         if args.name:
@@ -384,22 +375,13 @@ def handle_azure(args):
         assessment_type = require_env_int(
             "ESC_ASSESSMENT_TYPE", "assessment type (1 or 2)", {1, 2}
         )
-        try:
-            provider_details = _azure_provider_noninteractive(args)
-        except ConfigError:
-            sys.exit(codes.CONFIG)
+        provider_details = _azure_provider_noninteractive(args)
     elif args.cli:
-        try:
-            provider_details = _azure_provider_from_cli()
-        except ConfigError:
-            return
+        provider_details = _azure_provider_from_cli()
         exit_strategy, assessment_type = prompt_required_inputs()
     else:
         exit_strategy, assessment_type = prompt_required_inputs()
-        try:
-            provider_details = _azure_provider_from_prompt()
-        except ConfigError:
-            return
+        provider_details = _azure_provider_from_prompt()
 
     config = build_config(
         cloud_provider, exit_strategy, assessment_type, provider_details, args
@@ -864,17 +846,20 @@ def main():
         return
 
     # Dispatch based on provided arguments
-    if args.cloud_provider == "aws":
-        handle_aws(args)
-    elif args.cloud_provider == "azure":
-        handle_azure(args)
-    else:
-        console.print(
-            "[red]Invalid command. Use 'aws' or 'azure' as the first argument.[/red]"
-        )
-        console.print(
-            "[green]Run 'python3 main.py --help' for usage instructions.[/green]"
-        )
+    try:
+        if args.cloud_provider == "aws":
+            handle_aws(args)
+        elif args.cloud_provider == "azure":
+            handle_azure(args)
+        else:
+            console.print(
+                "[red]Invalid command. Use 'aws' or 'azure' as the first argument.[/red]"
+            )
+            console.print(
+                "[green]Run 'python3 main.py --help' for usage instructions.[/green]"
+            )
+    except ConfigError:
+        sys.exit(codes.CONFIG)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_and_main.py
+++ b/tests/test_utils_and_main.py
@@ -58,7 +58,6 @@ class LoadConfigTests(unittest.TestCase):
 
 
 def _base_patches():
-    """Patches that prevent real cloud/filesystem calls for all stage tests."""
     return [
         patch("main.console.print"),
         patch("main.print_step"),
@@ -93,7 +92,6 @@ def _base_patches():
 
 class RunAssessmentExitCodeTests(unittest.TestCase):
     def _run_with_patches(self, overrides: dict):
-        """Apply base patches, override specific ones, and run the assessment."""
         patches = _base_patches()
         for p in patches:
             p.start()
@@ -373,7 +371,6 @@ class RunAssessmentExitCodeTests(unittest.TestCase):
 
 
 def _ni_aws_args(**kwargs):
-    """Build a Namespace that looks like 'aws --non-interactive' with optional overrides."""
     defaults = dict(
         config=None,
         profile=None,
@@ -387,7 +384,6 @@ def _ni_aws_args(**kwargs):
 
 
 def _ni_azure_args(**kwargs):
-    """Build a Namespace that looks like 'azure --non-interactive' with optional overrides."""
     defaults = dict(
         config=None,
         cli=False,
@@ -523,7 +519,7 @@ class NonInteractiveAzureTests(unittest.TestCase):
         self.assertEqual(config_arg["providerDetails"]["clientId"], "client-id-456")
         self.assertNotIn("clientSecret", config_arg["providerDetails"])
 
-    def test_missing_client_id_for_oidc_exits_config(self):
+    def test_missing_client_id_for_oidc_raises_config_error(self):
         env = {
             k: v
             for k, v in self._BASE_ENV.items()
@@ -533,9 +529,8 @@ class NonInteractiveAzureTests(unittest.TestCase):
             patch.dict(os.environ, env, clear=False),
             patch("main.console.print"),
         ):
-            with self.assertRaises(SystemExit) as ctx:
+            with self.assertRaises(main.ConfigError):
                 main.handle_azure(_ni_azure_args())
-        self.assertEqual(ctx.exception.code, codes.CONFIG)
 
     def test_missing_subscription_id_exits_config(self):
         env = {k: v for k, v in self._BASE_ENV.items() if k != "ESC_SUBSCRIPTION_ID"}
@@ -782,6 +777,44 @@ class EgressStageTests(unittest.TestCase):
             main.handle_aws(_ni_aws_args(egress=True))
 
         mock_run.assert_called_once_with(ANY, "aws", dry_run=False, egress=True)
+
+
+class MainExitCodeTests(unittest.TestCase):
+    def test_config_error_from_handler_exits_config(self):
+        with (
+            patch("main.initialize_dataset"),
+            patch("main.console.print"),
+            patch(
+                "main.parse_arguments",
+                return_value=Namespace(cloud_provider="aws"),
+            ),
+            patch("main.handle_aws", side_effect=main.ConfigError),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main.main()
+        self.assertEqual(ctx.exception.code, codes.CONFIG)
+
+    def test_bad_config_file_exits_config_end_to_end(self):
+        args = Namespace(
+            cloud_provider="aws",
+            config="/nonexistent/aws.json",
+            profile=None,
+            name=None,
+            non_interactive=False,
+            dry_run=False,
+            egress=False,
+        )
+        with (
+            patch("main.initialize_dataset"),
+            patch("main.console.print"),
+            patch("main.parse_arguments", return_value=args),
+            patch("main.load_config", return_value=None),
+            patch("main.run_assessment") as mock_run,
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main.main()
+        self.assertEqual(ctx.exception.code, codes.CONFIG)
+        mock_run.assert_not_called()
 
 
 class ResolveModeEnvVarTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Config-resolution failures had two inconsistent conventions: non-interactive paths called `sys.exit(codes.CONFIG)`, while interactive paths (`--profile`, `--cli`, manual prompts) and the `--config <bad file>` path just `return`ed - meaning **the process exited 0 on those failures**. A CLI that exits 0 on failure silently breaks any script wrapping it (`set -e`, `&&`, `$?` checks).

This PR routes every config failure through the `ConfigError` seam introduced in the config-resolution refactor (#50) and maps it to an exit code in exactly one place.

## What changed

- `handle_aws` / `handle_azure`: the `--config`-file failure now raises
  `ConfigError` instead of `return`ing, and all six per-branch
  `try/except ConfigError` blocks were removed — resolvers now propagate freely.
- `main()`: a single `except ConfigError: sys.exit(codes.CONFIG)` wraps the
  provider dispatch, so file and credential failures — interactive or not — all
  exit `2` from one choke point.