### PR TITLE
Hide secret input with getpass for AWS/Azure manual entry

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import boto3
 import time
 import sys
 import os
+import getpass
 from rich.console import Console
 from datetime import datetime
 from botocore.exceptions import NoCredentialsError, ProfileNotFound
@@ -135,7 +136,7 @@ def _aws_provider_from_env() -> dict:
 def _aws_provider_from_prompt() -> dict:
     try:
         access_key = input("Enter AWS Access Key: ").strip()
-        secret_key = input("Enter AWS Secret Key: ").strip()
+        secret_key = getpass.getpass("Enter AWS Secret Key (input hidden): ").strip()
 
         # Validate AWS region input
         while True:
@@ -318,7 +319,7 @@ def _azure_provider_from_cli() -> dict:
 def _azure_provider_from_prompt() -> dict:
     tenant_id = input("Enter Azure Tenant ID: ").strip()
     client_id = input("Enter Service Principal / Client ID: ").strip()
-    client_secret = input("Enter Client Secret: ").strip()
+    client_secret = getpass.getpass("Enter Client Secret (input hidden): ").strip()
 
     try:
         credential = ClientSecretCredential(


### PR DESCRIPTION
## Summary

Manual credential entry echoed secrets to the terminal in plaintext. This swaps the two sensitive prompts from `input()` to `getpass.getpass()`, so the values are no longer displayed on screen or left in shell scrollback.

## Changes

- Added `import getpass` (stdlib — no new dependency, no `requirements.txt` change)
- AWS `secret_key` (`_aws_provider_from_prompt`) now read via `getpass.getpass()`
- Azure `client_secret` (`_azure_provider_from_prompt`) now read via `getpass.getpass()`

Non-secret identifiers (AWS access key ID, Azure tenant ID, client ID) remain visible `input()` so users can catch typos.