### PR TITLE
Remove unused plotly and kaleido dependencies

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,8 +59,6 @@ logging.basicConfig(
 )
 logging.getLogger("botocore").setLevel(logging.WARNING)
 logging.getLogger("boto3").setLevel(logging.WARNING)
-logging.getLogger("kaleido").setLevel(logging.WARNING)
-logging.getLogger("choreographer").setLevel(logging.WARNING)
 
 # Configure the logger
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ dependencies = [
     "Jinja2==3.1.6",
     "reportlab==4.5.0",
     "pillow==12.3.0",
-    "plotly==6.7.0",
-    "kaleido==1.3.0",
     "requests==2.33.1",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,4 @@ rich==15.0.0
 Jinja2==3.1.6
 reportlab==4.5.0
 pillow==12.3.0
-plotly==6.7.0
-kaleido==1.3.0
 requests==2.33.1


### PR DESCRIPTION
## Summary

Removes the `plotly` and `kaleido` packages, which are no longer used.

These were part of an old charting stack (Plotly for figures, kaleido as its
image-export backend). Chart and image generation now runs entirely on
ReportLab's native graphics primitives (`Drawing`, `Pie`, `Polygon`, `Wedge`,
etc. in `core/utils_report_pdf.py` and `core/utils_report_egress.py`). No Plotly
usage remains anywhere in the codebase — only leftover log-silencing lines — so
both packages are dead weight. kaleido also ships a bundled Chromium binary, so
dropping it meaningfully slims the install.

## Changes

- Remove `plotly==6.7.0` and `kaleido==1.3.0` from `requirements.txt`
- Remove `plotly==6.7.0` and `kaleido==1.3.0` from `pyproject.toml`
- Remove the leftover `kaleido` and `choreographer` logging lines in `main.py`